### PR TITLE
chore: missed node-18 releases

### DIFF
--- a/.github/workflows/lint-pr-title-preview-outputErrorMessage.yml
+++ b/.github/workflows/lint-pr-title-preview-outputErrorMessage.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
       - run: yarn install
       - run: yarn build
       - uses: ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: 'Release'
+name: "Release"
 on:
   push:
     branches:
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
       - run: yarn install
       - run: yarn build
       - run: yarn semantic-release


### PR DESCRIPTION
node release version to version 18, also added .yml extension to errormessage file